### PR TITLE
Fix Internet Gateway YAML snippet

### DIFF
--- a/snippets/yaml-snippets.json
+++ b/snippets/yaml-snippets.json
@@ -432,7 +432,7 @@
 			"${4:AttachGateway}:",
 			"  Type: AWS::EC2::VPCGatewayAttachment",
 			"  Properties:",
-			"    VpcId: ${4:vpc-id}",
+			"    VpcId: ${5:vpc-id}",
 			"    InternetGatewayId: !Ref ${1:igwName}"
 		],
 		"description": "",


### PR DESCRIPTION
## Problem
The Internet Gateway YAML snippet did a multiple cursor edit on the Attachment name and VpcId fields.

## Solution
Increased the cursor order of the VpcId field by one.